### PR TITLE
py3-fixes:

### DIFF
--- a/FCADLogger.py
+++ b/FCADLogger.py
@@ -110,4 +110,4 @@ class FCADLogger:
 
             import PySide
             PySide.QtGui.QMessageBox.critical(
-                    FreeCADGui.getMainWindow(),'Assembly',e.message)
+                    FreeCADGui.getMainWindow(),'Assembly',str(e))

--- a/constraint.py
+++ b/constraint.py
@@ -1,3 +1,4 @@
+from six import with_metaclass
 from collections import namedtuple
 import FreeCAD, FreeCADGui, Part
 from . import utils, gui
@@ -583,8 +584,7 @@ def cstrName(obj):
     return '{}<{}>'.format(objName(obj),Constraint.getTypeName(obj))
 
 
-class Base(object):
-    __metaclass__ = Constraint
+class Base(with_metaclass(Constraint, object)):
     _id = -1
     _entityDef = ()
     _workplane = False

--- a/gui.py
+++ b/gui.py
@@ -1,3 +1,4 @@
+from six import with_metaclass
 from collections import OrderedDict
 import FreeCAD, FreeCADGui
 from .utils import getElementPos,objName,addIconToFCAD,guilogger as logger
@@ -177,8 +178,7 @@ class AsmCmdManager(ProxyType):
     def onClearSelection(cls):
         pass
 
-class AsmCmdBase(object):
-    __metaclass__ = AsmCmdManager
+class AsmCmdBase(with_metaclass(AsmCmdManager, object)):
     _id = -1
     _active = None
     _toolbarName = 'Assembly3'

--- a/proxy.py
+++ b/proxy.py
@@ -61,7 +61,7 @@ class ProxyType(type):
 
     @classmethod
     def getType(mcs,tp):
-        if isinstance(tp,basestring):
+        if isinstance(tp,str):
             return mcs.getInfo().TypeNameMap[tp]
         if not isinstance(tp,int):
             tp = mcs.getTypeID(tp)

--- a/solver.py
+++ b/solver.py
@@ -110,7 +110,7 @@ class Solver(object):
                     msg += '\n{}, handle: {}'.format(cstrName(cstr),h)
                 logger.error(msg)
             raise RuntimeError('Failed to solve {}: {}'.format(
-                objName(assembly),e.message))
+                objName(assembly),str(e)))
         self.system.log('done solving')
 
         touched = False

--- a/sys_slvs.py
+++ b/sys_slvs.py
@@ -1,3 +1,4 @@
+from six import with_metaclass
 from .system import System, SystemBase, SystemExtension
 from .utils import syslogger as logger, objName
 import platform
@@ -5,10 +6,12 @@ import platform
 if platform.system() == 'Darwin':
     from .py_slvs_mac import slvs
 else:
-    from .py_slvs import slvs
+    try:
+        from py_slvs import slvs
+    except ImportError:
+        from .py_slvs import slvs
 
-class SystemSlvs(SystemBase):
-    __metaclass__ = System
+class SystemSlvs(with_metaclass(System, SystemBase)):
     _id = 1
 
     def __init__(self,obj):

--- a/sys_sympy.py
+++ b/sys_sympy.py
@@ -1,3 +1,4 @@
+from six import with_metaclass
 from collections import namedtuple
 import pprint
 from .proxy import ProxyType, PropertyInfo
@@ -30,8 +31,7 @@ def _makeProp(name,doc='',tp='App::PropertyFloat',group=None):
 
 _makeProp('Tolerance','','App::PropertyPrecision','Solver')
 
-class _AlgoBase(object):
-    __metaclass__ = _AlgoType
+class _AlgoBase(with_metaclass(_AlgoType, object)):
     _id = -2
     _common_options = [_makeProp('maxiter',
         'Maximum number of function evaluations','App::PropertyInteger')]
@@ -207,8 +207,7 @@ class _Algodogleg(_AlgoNeedHessian):
 class _Algotrust_ncg(_Algodogleg):
     _id = 10
 
-class SystemSymPy(SystemBase):
-    __metaclass__ = System
+class SystemSymPy(with_metaclass(System, SystemBase)):
     _id = 2
 
     def __init__(self,obj):
@@ -319,8 +318,7 @@ class _MetaType(type):
             return issubclass(cls,_Constraint)
 
 
-class _MetaBase(_Base):
-    __metaclass__ = _MetaType
+class _MetaBase(with_metaclass(_MetaType, _Base)):
     _args = ()
     _opts = ()
     _vargs = ()

--- a/system.py
+++ b/system.py
@@ -1,3 +1,4 @@
+from six import with_metaclass
 import os
 import FreeCAD
 from .constraint import cstrName, PlaneInfo, NormalInfo
@@ -76,8 +77,7 @@ def _makePropInfo(name,tp,doc='',default=None):
 _makePropInfo('Verbose','App::PropertyBool')
 _makePropInfo('AutoRelax','App::PropertyBool')
 
-class SystemBase(object):
-    __metaclass__ = System
+class SystemBase(with_metaclass(System, object)):
     _id = 0
     _props = ['Verbose','AutoRelax']
 

--- a/utils.py
+++ b/utils.py
@@ -590,4 +590,3 @@ def project2D(rot,*vectors):
     vx = rot.multVec(FreeCAD.Vector(1,0,0))
     vy = rot.multVec(FreeCAD.Vector(0,1,0))
     return [FreeCAD.Vector(v.dot(vx),v.dot(vy),0) for v in vectors]
-


### PR DESCRIPTION
- use six.with_metaclas(metaclass, baseclass)
- some imports must be handled in a different way if py_solve is a external package (conda)

please review carefully if you are happy with the changes for the import of py_slvs. I can also change the conda-package...

edit2: I am able to use assembly3 with this changes.
edit3: and we should also check if six is available on all plattforms.