### PR TITLE
do not block other namespace-packages

### DIFF
--- a/freecad/__init__.py
+++ b/freecad/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
It's also possible to remove the freecad/__init__.py file but this works only with py3. Not sure if this workbench should also work with py2.