### PR TITLE
Declare this package as a namespace package

### DIFF
--- a/freecad/__init__.py
+++ b/freecad/__init__.py
@@ -1,1 +1,2 @@
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__import__("pkg_resources").declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,6 @@ setup(name='freecad.asm3',
                 'freecad.asm3'],
       url="https://github.com/realthunder/FreeCAD_assembly3",
       description="Experimental attempt for the next generation assembly workbench for FreeCAD ",
+      namespace_packages=["freecad"],
       install_requires=["six"],
       include_package_data=True)


### PR DESCRIPTION
this allows it to be (pip-) installed alongside other freecad packages.

specifically, the occasion is for the workbench I'm developing that builds on freecad.asm3 but in general it should be good practice and does no harm :)
