### PR TITLE
try setuptools' method first, then fallback

### DIFF
--- a/freecad/__init__.py
+++ b/freecad/__init__.py
@@ -1,2 +1,5 @@
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
-__import__("pkg_resources").declare_namespace(__name__)
+try:
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    __path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
Instead of unconditionally doing both. This avoids the need for the user to have setuptools installed in order for this plugin to function properly. My knowledge of what exactly is going on here is limited, but from what I can tell, these two statements were basically identical, so only one of them should need to be executed. Doing some simple stuff with the solvespace solver seemed to work okay.