### PR TITLE
simplify pip install

### DIFF
--- a/freecad/__init__.py
+++ b/freecad/__init__.py
@@ -1,5 +1,0 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    __path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,8 @@ with open(version_path) as fp:
 
 setup(name='freecad.asm3',
       version=str(__version__),
-      packages=['freecad',
-                'freecad.asm3'],
+      packages=['freecad.asm3'],
       url="https://github.com/realthunder/FreeCAD_assembly3",
       description="Experimental attempt for the next generation assembly workbench for FreeCAD ",
-      namespace_packages=["freecad"],
       install_requires=["six"],
       include_package_data=True)


### PR DESCRIPTION
@tomster @realthunder @CobaltCause

can you check if this works for you. This package is for sure a name-space package. But the freecad internal `__init__.py` should not be overwritten, as it works as a helper to find the FreeCAD library. Also I had issue with other freecad-namespace-packages due to freecad.asm3...