### PR TITLE
Treat objects that are attached to other objects as fixed parts

### DIFF
--- a/freecad/asm3/constraint.py
+++ b/freecad/asm3/constraint.py
@@ -540,6 +540,10 @@ class Constraint(ProxyType):
             if not hasattr(obj,'Placement'):
                 ret.add(obj)
                 logger.debug('part without Placement {}',objName(obj))
+            # Treat objects that are attached to other objects (e.g. sketches) as fixed parts. Their placement will be calculated by the attachment.
+            elif obj.hasExtension('Part::AttachExtension') and obj.AttachmentSupport:
+                ret.add(obj)
+                logger.debug('part with AttachExtension {}',objName(obj))
             elif isTypeOf(obj,AsmWorkPlane) and getattr(obj,'Fixed',False):
                 ret.add(obj)
                 logger.debug('fix workplane {}',objName(obj))


### PR DESCRIPTION
I was using a sketch from the Sketch WB to define some geometry so I can attach other parts to it. After constraining the other parts, the placement property of the sketch got some weird angles. I found out that the placement of the sketch was overwritten by the assembly solver.

I find it unintiutive that a sketch that is attached to some face will be repositions by the solver. I added a check to assembly3 that should treat any object with the AttachExtension and a valid AttachmentSuport as a fixed part so the solver will not overwrite the placement.