### PR TITLE
Replaced PySide2 ref with PySide

### DIFF
--- a/freecad/asm3/init_gui.py
+++ b/freecad/asm3/init_gui.py
@@ -52,7 +52,7 @@ class Assembly3Workbench(FreeCADGui.Workbench):
             cmd.workbenchActivated()
 
         if not 'freecad.asm3.sys_slvs' in sys.modules:
-            from PySide2.QtCore import QTimer
+            from PySide.QtCore import QTimer
             QTimer.singleShot(100, self.check_slvs)
 
     def Deactivated(self):

--- a/freecad/asm3/install_prompt.py
+++ b/freecad/asm3/install_prompt.py
@@ -3,8 +3,8 @@ import sys
 import os.path
 import platform
 import subprocess as subp
-from PySide2.QtWidgets import QCheckBox, QMessageBox
-from PySide2.QtCore import QTimer
+from PySide.QtWidgets import QCheckBox, QMessageBox
+from PySide.QtCore import QTimer
 from .utils import guilogger as logger
 
 from FreeCAD import Qt


### PR DESCRIPTION
Hi,

I'm noticed an issue with Assembly3 WB and the new FreeCAD with QT6. This was caused by a PySide2 reference. I've changed this to PySide. 

kind regards, 