### PR TITLE
FreeCADWeb.Org ➞ FreeCAD.Org

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@
 [![paypal](https://img.shields.io/badge/Donate-PayPal-blue.svg)](https://www.paypal.me/realthunder)
 
 Assembly3 workbench is yet another attempt to bring assembly capability to
-[FreeCAD](http://www.freecadweb.org/). There is the original unfinished
+[FreeCAD]. There is the original unfinished
 Assembly workbench in FreeCAD source tree, and
 [Assembly2](https://github.com/hamish2014/FreeCAD_assembly2), which is an
 inspiration of this workbench, and with some code borrowed as well. The
@@ -54,9 +54,9 @@ e.g. `Python3 -m pip install py_slvs`. **The workspace will not function properl
 ## Design
 
 The design of Assembly3 (and the fork of FreeCAD) partially follows the
-unfinished FreeCAD Assembly [project plan](https://www.freecadweb.org/wiki/Assembly_project), 
-in particularly, the section [Infrastructure](https://www.freecadweb.org/wiki/Assembly_project#Infrastructure)
-and [Object model](https://www.freecadweb.org/wiki/Assembly_project#Object_model).
+unfinished FreeCAD Assembly [project plan][Plan],
+in particularly, the section [Infrastructure]
+and [Object model][Model].
 You can find more details at [here](../../wiki/Design).
 
 ## Usage
@@ -109,3 +109,9 @@ a brief list of comparison between Assembly2 to Assembly3.
   allow you to interactively drag any part of the assembly under constraint in
   real time.
 
+
+[FreeCAD]: https://freecad.org
+
+[Infrastructure]: https://web.archive.org/web/20170409104503/https://www.freecadweb.org/wiki/Assembly_project#Infrastructure
+[Model]: https://web.archive.org/web/20170409104503/https://www.freecadweb.org/wiki/Assembly_project#Object_model
+[Plan]: https://web.archive.org/web/20170409104503/https://www.freecadweb.org/wiki/Assembly_project

--- a/freecad/asm3/Gui/Resources/icons/AssemblyWorkbench.svg
+++ b/freecad/asm3/Gui/Resources/icons/AssemblyWorkbench.svg
@@ -665,7 +665,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Add_New_Part.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Add_New_Part.svg
@@ -135,7 +135,7 @@
         </dc:creator>
         <dc:title>Assembly_Add_New_Part</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Add_Origin.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Add_Origin.svg
@@ -163,7 +163,7 @@
         </dc:creator>
         <dc:title>Sketcher_Sketch</dc:title>
         <dc:date>2011-10-10</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Add_Placement.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Add_Placement.svg
@@ -79,7 +79,7 @@
         <dc:title></dc:title>
         <dc:title>Path-Heights</dc:title>
         <dc:date>2016-05-15</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Add_Workplane.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Add_Workplane.svg
@@ -100,7 +100,7 @@
         <dc:title />
         <dc:title>Path-Heights</dc:title>
         <dc:date>2016-05-15</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Add_WorkplaneXZ.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Add_WorkplaneXZ.svg
@@ -100,7 +100,7 @@
         <dc:title></dc:title>
         <dc:title>Path-Heights</dc:title>
         <dc:date>2016-05-15</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Add_WorkplaneZY.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Add_WorkplaneZY.svg
@@ -100,7 +100,7 @@
         <dc:title></dc:title>
         <dc:title>Path-Heights</dc:title>
         <dc:date>2016-05-15</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Constraints_Tree.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Constraints_Tree.svg
@@ -502,7 +502,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Constraints_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Create_New.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Create_New.svg
@@ -170,7 +170,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Create_New</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Element.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Element.svg
@@ -573,7 +573,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_ElementDetached.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_ElementDetached.svg
@@ -595,7 +595,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Element_Tree.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Element_Tree.svg
@@ -586,7 +586,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Frozen_Tree.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Frozen_Tree.svg
@@ -653,7 +653,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Part_Tree.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Part_Tree.svg
@@ -526,7 +526,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Part_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Relation_Tree.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Relation_Tree.svg
@@ -610,7 +610,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Tree.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Assembly_Tree.svg
@@ -137,7 +137,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_AutoElementVis.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_AutoElementVis.svg
@@ -449,7 +449,7 @@
         </dc:creator>
         <dc:title>OpenSCAD_RemoveSubtree</dc:title>
         <dc:date>2012-05-03</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_AutoFixElement.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_AutoFixElement.svg
@@ -574,7 +574,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_AutoRecompute.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_AutoRecompute.svg
@@ -957,7 +957,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Create_New</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_AxialMove.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_AxialMove.svg
@@ -58,7 +58,7 @@
         <dc:title />
         <dc:title>Path-Axis</dc:title>
         <dc:date>2015-07-04</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_ConstraintMultiply.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_ConstraintMultiply.svg
@@ -481,7 +481,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_GotoRelation.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_GotoRelation.svg
@@ -607,7 +607,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Import.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Import.svg
@@ -620,7 +620,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_ImportMulti.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_ImportMulti.svg
@@ -596,7 +596,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_LockMover.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_LockMover.svg
@@ -471,7 +471,7 @@
           </cc:Agent>
         </dc:publisher>
         <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Move.svg</dc:identifier>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:contributor>
           <cc:Agent>
             <dc:title>[agryson] Alexander Gryson</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Move.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Move.svg
@@ -378,7 +378,7 @@
           </cc:Agent>
         </dc:publisher>
         <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Move.svg</dc:identifier>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:contributor>
           <cc:Agent>
             <dc:title>[agryson] Alexander Gryson</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_New_Assembly.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_New_Assembly.svg
@@ -124,7 +124,7 @@
         </dc:creator>
         <dc:title>Assembly_Add_Existing_Part</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_New_Element.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_New_Element.svg
@@ -573,7 +573,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_QuickMove.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_QuickMove.svg
@@ -619,7 +619,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_QuickSolve.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_QuickSolve.svg
@@ -665,7 +665,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_ShowElementCS.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_ShowElementCS.svg
@@ -120,7 +120,7 @@
         <dc:title></dc:title>
         <dc:title>Path-Axis</dc:title>
         <dc:date>2015-07-04</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_SmartRecompute.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_SmartRecompute.svg
@@ -940,7 +940,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Create_New</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_TogglePartVisibility.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_TogglePartVisibility.svg
@@ -610,7 +610,7 @@
         </dc:creator>
         <dc:title>Assembly_Assembly_Tree</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Trace.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Trace.svg
@@ -811,7 +811,7 @@
         </dc:creator>
         <dc:title>Ship_CapacityCurve</dc:title>
         <dc:date>2014-12-12</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_TreeItemDown.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_TreeItemDown.svg
@@ -459,7 +459,7 @@
         </dc:creator>
         <dc:title>OpenSCAD_RemoveSubtree</dc:title>
         <dc:date>2012-05-03</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_TreeItemUp.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_TreeItemUp.svg
@@ -459,7 +459,7 @@
         </dc:creator>
         <dc:title>OpenSCAD_RemoveSubtree</dc:title>
         <dc:date>2012-05-03</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/Assembly_Workplane.svg
+++ b/freecad/asm3/Gui/Resources/icons/Assembly_Workplane.svg
@@ -79,7 +79,7 @@
         <dc:title></dc:title>
         <dc:title>Path-Heights</dc:title>
         <dc:date>2016-05-15</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintAlignment.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintAlignment.svg
@@ -725,7 +725,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintAlignment</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintAngle.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintAngle.svg
@@ -451,7 +451,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintAngle</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintArcLineTangent.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintArcLineTangent.svg
@@ -367,7 +367,7 @@
         </dc:creator>
         <dc:title>Constraint_TangentToStart</dc:title>
         <dc:date>2011-10-10</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintAttachment.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintAttachment.svg
@@ -178,7 +178,7 @@
         </dc:creator>
         <dc:title>Part_Attachment</dc:title>
         <dc:date>2016-05-17</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintAttachmentOffset.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintAttachmentOffset.svg
@@ -170,7 +170,7 @@
         </dc:creator>
         <dc:title>Part_Attachment</dc:title>
         <dc:date>2016-05-17</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintAxial.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintAxial.svg
@@ -482,7 +482,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintOpposite</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintBidirectional.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintBidirectional.svg
@@ -129,7 +129,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintBidirectional</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintCoincidence.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintCoincidence.svg
@@ -440,7 +440,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintCoincidence</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintColinear.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintColinear.svg
@@ -538,7 +538,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintDiameter.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintDiameter.svg
@@ -560,7 +560,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintDistance.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintDistance.svg
@@ -114,7 +114,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintDistance</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqual.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqual.svg
@@ -109,7 +109,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintEqual</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqualAngle.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqualAngle.svg
@@ -429,7 +429,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintAngle</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqualLength.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqualLength.svg
@@ -448,7 +448,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqualLineArcLength.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqualLineArcLength.svg
@@ -771,7 +771,7 @@
         </dc:creator>
         <dc:title>Constraint_TangentToStart</dc:title>
         <dc:date>2011-10-10</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqualPointLineDistance.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqualPointLineDistance.svg
@@ -470,7 +470,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqualRadius.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintEqualRadius.svg
@@ -538,7 +538,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintGeneral.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintGeneral.svg
@@ -121,7 +121,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintGeneral</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLengthDifference.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLengthDifference.svg
@@ -538,7 +538,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLengthEqualPointLineDistance.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLengthEqualPointLineDistance.svg
@@ -470,7 +470,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLengthRatio.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLengthRatio.svg
@@ -448,7 +448,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLineHorizontal.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLineHorizontal.svg
@@ -211,7 +211,7 @@
         </dc:creator>
         <dc:title>Tree_Part_Cylinder_Parametric</dc:title>
         <dc:date>2013-03-13</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLineLength.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLineLength.svg
@@ -561,7 +561,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLineVertical.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLineVertical.svg
@@ -201,7 +201,7 @@
         </dc:creator>
         <dc:title>Tree_Part_Cylinder_Parametric</dc:title>
         <dc:date>2013-03-13</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLock.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintLock.svg
@@ -528,7 +528,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintLock</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintMidPoint.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintMidPoint.svg
@@ -246,7 +246,7 @@
         </dc:creator>
         <dc:title>Tree_Part_Cylinder_Parametric</dc:title>
         <dc:date>2013-03-13</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintMore.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintMore.svg
@@ -451,7 +451,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintMultiParallel.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintMultiParallel.svg
@@ -536,7 +536,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintOrientation.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintOrientation.svg
@@ -628,7 +628,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintOrientation</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintParallel.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintParallel.svg
@@ -482,7 +482,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintOpposite</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPerpendicular.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPerpendicular.svg
@@ -546,7 +546,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintPerpendicular</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointCoincident.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointCoincident.svg
@@ -315,7 +315,7 @@
         </dc:creator>
         <dc:title>Constraint_PointOnPoint</dc:title>
         <dc:date>2011-10-10</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointDistance.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointDistance.svg
@@ -504,7 +504,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointInPlane.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointInPlane.svg
@@ -519,7 +519,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointLineDistance.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointLineDistance.svg
@@ -493,7 +493,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointOnCircle.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointOnCircle.svg
@@ -504,7 +504,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointOnLine.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointOnLine.svg
@@ -224,7 +224,7 @@
         </dc:creator>
         <dc:title>Tree_Part_Cylinder_Parametric</dc:title>
         <dc:date>2013-03-13</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointPlaneDistance.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointPlaneDistance.svg
@@ -518,7 +518,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointsDistance.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointsDistance.svg
@@ -504,7 +504,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointsHorizontal.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointsHorizontal.svg
@@ -207,7 +207,7 @@
         </dc:creator>
         <dc:title>Tree_Part_Cylinder_Parametric</dc:title>
         <dc:date>2013-03-13</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointsProjectDistance.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointsProjectDistance.svg
@@ -538,7 +538,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointsSymmetric.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointsSymmetric.svg
@@ -503,7 +503,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointsVertical.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintPointsVertical.svg
@@ -209,7 +209,7 @@
         </dc:creator>
         <dc:title>Tree_Part_Cylinder_Parametric</dc:title>
         <dc:date>2013-03-13</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintSketchPlane.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintSketchPlane.svg
@@ -79,7 +79,7 @@
         <dc:title></dc:title>
         <dc:title>Path-Heights</dc:title>
         <dc:date>2016-05-15</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintSymmetric.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintSymmetric.svg
@@ -533,7 +533,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintSymmetricLine.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintSymmetricLine.svg
@@ -482,7 +482,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintUnidirectional1.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintUnidirectional1.svg
@@ -129,7 +129,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintUnidirectional1</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintUnidirectional2.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_ConstraintUnidirectional2.svg
@@ -129,7 +129,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintUnidirectional2</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_MeasureAngle.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_MeasureAngle.svg
@@ -481,7 +481,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintAngle</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_MeasurePointDistance.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_MeasurePointDistance.svg
@@ -503,7 +503,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_MeasurePointLineDistance.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_MeasurePointLineDistance.svg
@@ -492,7 +492,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>

--- a/freecad/asm3/Gui/Resources/icons/constraints/Assembly_MeasurePointPlaneDistance.svg
+++ b/freecad/asm3/Gui/Resources/icons/constraints/Assembly_MeasurePointPlaneDistance.svg
@@ -517,7 +517,7 @@
         </dc:creator>
         <dc:title>Assembly_ConstraintParallel</dc:title>
         <dc:date>2013-12-24</dc:date>
-        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:relation>https://wiki.freecad.org/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>


### PR DESCRIPTION
This PR updates references to the  
old FreeCAD website with new ones.

Also replaced the dead wiki links  
with waybbackmachine backups.